### PR TITLE
Expose conversation object and allow it to be passed in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log
 yarn.lock
 node_modules/
 dist/
+OG/
 .parcel-cache
 db.json
 .env

--- a/examples/cli.js
+++ b/examples/cli.js
@@ -9,19 +9,18 @@ const rl = readline.createInterface({
   output: process.stdout
 });
 
-let cookies = `NID=; SID=; __Secure-1PSID=; __Secure-3PSID=; HSID=; SSID=; APISID=; SAPISID=; __Secure-1PAPISID=; __Secure-3PAPISID=; SIDCC=; __Secure-1PSIDCC=; __Secure-3PSIDCC=`;
+let cookies = `__Secure-1PSID=Uwipm0y7yXwfePHWX4g8U8mYN5CX-qiu1G0EIiziHbMgwqo2ka0ulXKEwQpayygxrNcybw.`;
 
-let bot = new Bard(cookies, {
-  proxy: {  // optional
-    host: process.env.PROXY_HOST,
-    port: process.env.PROXY_PORT,
-    auth: {
-      username: process.env.PROXY_USERNAME,
-      password: process.env.PROXY_PASSWORD
-    },
-    protocol: process.env.PROXY_PROTOCOL
-  }
-});
+let yourConversationObject = `{"conversationId":"c_93c9fbe53c884882","requestId":"r_93c9fbe53c884b3b","responseId":"rc_93c9fbe53c884279","responses":["It is a pleasure to meet you, Eris. I am Bard.","Eris","It is a pleasure to meet you, Eris. I am Bard.","It is a pleasure to meet you, Eris! I am Bard. What can I help you with today?","Hello Eris! It's a pleasure to meet you. I'm Bard."]}`
+
+let conversationObject = {}
+
+if (yourConversationObject) {
+  conversationObject = JSON.parse(yourConversationObject)
+  console.log(`Your conversation object was loaded! The new object is ${JSON.stringify(conversationObject)}`)
+}
+
+let bot = new Bard(cookies);
 
 async function main() {
   while (true) {
@@ -32,9 +31,10 @@ async function main() {
     });
 
     process.stdout.write("Google Bard: ");
-    await bot.askStream(res => {
-      process.stdout.write(res.toString());
-    }, prompt);
+    conversationObject = await bot.ask(prompt, conversationObject)
+      process.stdout.write(conversationObject.responses[0]);
+      console.log()
+    process.stdout.write(`Conversation object: ${JSON.stringify(conversationObject)}`)
     console.log();
   }
 }

--- a/examples/cli.js
+++ b/examples/cli.js
@@ -9,7 +9,7 @@ const rl = readline.createInterface({
   output: process.stdout
 });
 
-let cookies = `__Secure-1PSID=Uwipm0y7yXwfePHWX4g8U8mYN5CX-qiu1G0EIiziHbMgwqo2ka0ulXKEwQpayygxrNcybw.`;
+let cookies = `__Secure-1PSID=`;
 
 let yourConversationObject = `{"conversationId":"c_93c9fbe53c884882","requestId":"r_93c9fbe53c884b3b","responseId":"rc_93c9fbe53c884279","responses":["It is a pleasure to meet you, Eris. I am Bard.","Eris","It is a pleasure to meet you, Eris. I am Bard.","It is a pleasure to meet you, Eris! I am Bard. What can I help you with today?","Hello Eris! It's a pleasure to meet you. I'm Bard."]}`
 

--- a/src/classes/bard.ts
+++ b/src/classes/bard.ts
@@ -9,11 +9,6 @@ import AppDbContext from "./app-dbcontext.js";
 import Conversation from "../models/conversation.js";
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 
-type cObject = {
-  
-
-}
-
 class Bard {
 	private axios: AxiosInstance;
 	private db: AppDbContext;

--- a/src/classes/bard.ts
+++ b/src/classes/bard.ts
@@ -224,7 +224,8 @@ class Bard {
 			  conversationId: conversation.c,
 		          requestId: conversation.r,
 		          responseId: conversation.rc,
-		          responses: parsedResponse.responses
+		          responses: parsedResponse.responses,
+		          lastActive: Date.now(),
 			}
 
 			return finalResponse;

--- a/src/classes/bard.ts
+++ b/src/classes/bard.ts
@@ -165,7 +165,7 @@ class Bard {
 
 	public async ask(prompt: string, conversationObject?: { conversationId: string, requestId: string, responseId: string }, conversationId?: string) {
 		// return await this.askStream((data) => {}, prompt, conversationId);
-		let resData = await this.send(prompt, conversationId, conversationObject,);
+		let resData = await this.send(prompt, conversationId, conversationObject);
 		return resData;
 	}
 
@@ -188,7 +188,7 @@ class Bard {
 		  conversation.r = conversationObject.requestId
 		  conversation.rc = conversationObject.responseId
 		} else {
-		let conversation = this.getConversationById(conversationId);
+		conversation = this.getConversationById(conversationId);
 		}
 		try {
 			let { at, bl } = await this.GetRequestParams();


### PR DESCRIPTION
Allows users to see the needed IDs sent to Bard, and send their own object in for usage.

Needed for projects that store Bard conversations long-term.